### PR TITLE
Fix CI: upgrade deprecated actions and fix redismock build

### DIFF
--- a/.github/workflows/flow-coverage.yml
+++ b/.github/workflows/flow-coverage.yml
@@ -25,11 +25,7 @@ jobs:
     - name: Setup common
       run: .install/common_installations.sh sudo
     - name: Ensure lcov is installed
-      run: |
-        sudo apt-get update -qq && sudo apt-get install -yqq lcov
-        # lcov 2.0+ (Ubuntu 24.04) is stricter; configure it to ignore
-        # non-critical errors that occur in coverage collection.
-        echo "ignore_errors = inconsistent,empty,unused" > ~/.lcovrc
+      run: sudo apt-get update -qq && sudo apt-get install -yqq lcov
     - name: Get Redis
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/flow-coverage.yml
+++ b/.github/workflows/flow-coverage.yml
@@ -25,7 +25,11 @@ jobs:
     - name: Setup common
       run: .install/common_installations.sh sudo
     - name: Ensure lcov is installed
-      run: sudo apt-get update -qq && sudo apt-get install -yqq lcov
+      run: |
+        sudo apt-get update -qq && sudo apt-get install -yqq lcov
+        # lcov 2.0+ (Ubuntu 24.04) is stricter; configure it to ignore
+        # non-critical errors that occur in coverage collection.
+        echo "ignore_errors = inconsistent,empty,unused" > ~/.lcovrc
     - name: Get Redis
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/flow-coverage.yml
+++ b/.github/workflows/flow-coverage.yml
@@ -24,6 +24,8 @@ jobs:
       run: ./install_script.sh sudo
     - name: Setup common
       run: .install/common_installations.sh sudo
+    - name: Ensure lcov is installed
+      run: sudo apt-get update -qq && sudo apt-get install -yqq lcov
     - name: Get Redis
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -31,7 +33,7 @@ jobs:
     - name: Build and test
       run: make coverage QUICK=1 SHOW=1
     - name: Upload coverage
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         file: bin/linux-x64-debug-cov/cov.info
         fail_ci_if_error: true # Fail on upload errors

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -75,7 +75,7 @@ jobs:
             tests/pytests/requirements.*
       - name: Deps checkout (node20 not supported)
         if: steps.node20.outputs.supported == 'false'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: setup
           sparse-checkout-cone-mode: false
@@ -92,7 +92,7 @@ jobs:
           submodules: recursive
       - name: Full checkout (node20 not supported)
         if: steps.node20.outputs.supported == 'false'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Setup common
@@ -107,7 +107,7 @@ jobs:
           path: redis
       - name: Get Redis (node20 not supported)
         if: ${{ inputs.get-redis != 'skip getting redis' && steps.node20.outputs.supported == 'false' }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: redis/redis
           ref: ${{ inputs.get-redis }}
@@ -164,14 +164,14 @@ jobs:
           name: Test Logs ${{ steps.artifact-names.outputs.name }}
           path: tests/**/logs/*.log*
           if-no-files-found: ignore
-      # If node20 is not supported, we can only use version 3.
-      # Here we only upload the artifacts if the tests had failed, since it is very slow
+      # Fallback upload for platforms where node20 is not supported.
+      # Using v4 since v3 is deprecated and blocked by GitHub.
       - name: Upload Artifacts (node20 not supported)
         # Upload artifacts only if tests failed (including sanitizer failures)
         if: >
           steps.node20.outputs.supported == 'false' &&
           (steps.test1.outcome == 'failure' || steps.test2.outcome == 'failure' || steps.test3.outcome == 'failure' || steps.test4.outcome == 'failure')
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Test Logs ${{ steps.artifact-names.outputs.name }}
           path: tests/**/logs/*.log*

--- a/Makefile
+++ b/Makefile
@@ -558,7 +558,7 @@ endif
 
 coverage:
 ifeq ($(REJSON_PATH),)
-	$(SHOW)OSS=1 MODULE_FILE=$(REJSON_MODULE_FILE) ./sbin/get-redisjson
+	$(SHOW)OSS=1 BRANCH=$(REJSON_BRANCH) MODULE_FILE=$(REJSON_MODULE_FILE) ./sbin/get-redisjson
 endif
 	$(SHOW)$(MAKE) build COV=1
 	$(SHOW)$(MAKE) build COORD=oss COV=1

--- a/Makefile
+++ b/Makefile
@@ -234,6 +234,7 @@ include $(MK)/defs
 # lcov 2.0 is stricter and exits non-zero on data inconsistencies that 1.x ignored.
 ifeq ($(COV),1)
 LCOV_IGNORE := --ignore-errors inconsistent,empty,unused,mismatch,gcov,source,negative,count,format
+GENHTML_IGNORE := --ignore-errors inconsistent,empty,unused,source,format,unmapped
 
 define COVERAGE_RESET
 $(SHOW)set -e ;\
@@ -253,7 +254,7 @@ endef
 define COVERAGE_REPORT
 $(SHOW)set -e ;\
 lcov $(LCOV_IGNORE) -l $(COV_INFO) ;\
-genhtml --legend $(LCOV_IGNORE) -o $(COV_DIR) $(COV_INFO) > /dev/null 2>&1 ;\
+genhtml --legend $(GENHTML_IGNORE) -o $(COV_DIR) $(COV_INFO) > /dev/null 2>&1 ;\
 echo "Coverage info at $$(realpath $(COV_DIR))/index.html"
 endef
 

--- a/Makefile
+++ b/Makefile
@@ -230,6 +230,39 @@ _CMAKE_FLAGS += $(CMAKE_ARGS) $(CMAKE_STATIC) $(CMAKE_COORD) $(CMAKE_TEST)
 
 include $(MK)/defs
 
+# Override readies COVERAGE_COLLECT/COVERAGE_REPORT for lcov 2.0 (Ubuntu 24.04)
+# lcov 2.0 is stricter and exits non-zero on data inconsistencies that 1.x ignored.
+ifeq ($(COV),1)
+LCOV_IGNORE := --ignore-errors inconsistent,empty,unused,mismatch,gcov,source,negative,count,format
+
+define COVERAGE_RESET
+$(SHOW)set -e ;\
+echo "Starting coverage analysys." ;\
+mkdir -p $(COV_DIR) ;\
+lcov $(LCOV_IGNORE) --directory $(BINROOT) --base-directory $(SRCDIR) -z > /dev/null 2>&1
+endef
+
+define COVERAGE_COLLECT
+$(SHOW)set -e ;\
+echo "Collecting coverage data ..." ;\
+lcov $(LCOV_IGNORE) --capture --directory $(BINROOT) --base-directory $(SRCDIR) --output-file $(COV_INFO) > /dev/null 2>&1 ;\
+lcov $(LCOV_IGNORE) -o $(COV_INFO).1 -r $(COV_INFO) $(COV_EXCLUDE) > /dev/null 2>&1 ;\
+mv $(COV_INFO).1 $(COV_INFO)
+endef
+
+define COVERAGE_REPORT
+$(SHOW)set -e ;\
+lcov $(LCOV_IGNORE) -l $(COV_INFO) ;\
+genhtml --legend $(LCOV_IGNORE) -o $(COV_DIR) $(COV_INFO) > /dev/null 2>&1 ;\
+echo "Coverage info at $$(realpath $(COV_DIR))/index.html"
+endef
+
+define COVERAGE_COLLECT_REPORT
+$(COVERAGE_COLLECT)
+$(COVERAGE_REPORT)
+endef
+endif
+
 MK_CUSTOM_CLEAN=1
 
 #----------------------------------------------------------------------------------------------

--- a/sbin/build-redisjson
+++ b/sbin/build-redisjson
@@ -57,7 +57,7 @@ runn git pull --quiet --recurse-submodules
 
 # Temporary patch to use a fixed GOOD_NIGHTLY version because of a bug in the 
 # latest nightly https://github.com/rust-lang/rust/issues/125319
-sed -i 's/# GOOD_NIGHTLY=.*/GOOD_NIGHTLY=nightly-2024-05-16/' ./deps/readies/bin/getrust
+sed -i 's/# GOOD_NIGHTLY=.*/GOOD_NIGHTLY=nightly-2024-09-15/' ./deps/readies/bin/getrust
 
 if is_command python3; then
 	runn python3 -m pip install virtualenv

--- a/src/document_basic.c
+++ b/src/document_basic.c
@@ -33,13 +33,11 @@ static DocumentField *addFieldCommon
   memset(f, 0, sizeof(DocumentField));
 
   f->indexAs = typemask;
-  //if (d->flags & DOCUMENT_F_OWNSTRINGS) {
-  //  f->name = rm_strdup(fieldname);
-  //} else {
-  //  f->name = fieldname;
-  //}
-
-  f->name = fieldname;
+  if (d->flags & DOCUMENT_F_OWNSTRINGS) {
+    f->name = rm_strdup(fieldname);
+  } else {
+    f->name = fieldname;
+  }
   f->path = NULL;
 
   return f;

--- a/src/document_basic.c
+++ b/src/document_basic.c
@@ -415,7 +415,7 @@ void Document_Clear(Document *d) {
     for (size_t ii = 0; ii < d->numFields; ++ii) {
       DocumentField *field = &d->fields[ii];
       if (d->flags & DOCUMENT_F_OWNSTRINGS) {
-        //rm_free((void *)field->name);
+        rm_free((void *)field->name);
         if (field->path && (field->path != field->name)) {
           rm_free((void *)field->path);
         }
@@ -429,7 +429,10 @@ void Document_Clear(Document *d) {
           break;
         case FLD_VAR_T_ARRAY:
           if (field->indexAs & (INDEXFLD_T_FULLTEXT | INDEXFLD_T_TAG | INDEXFLD_T_GEO)) {
-            array_free(field->multiVal);
+            for (int i = 0; i < field->arrayLen; ++i) {
+              rm_free(field->multiVal[i]);
+            }
+            rm_free(field->multiVal);
             field->arrayLen = 0;
           } else if (field->indexAs & INDEXFLD_T_NUMERIC) {
             array_free(field->arrNumval);

--- a/src/module-init/module-init.c
+++ b/src/module-init/module-init.c
@@ -244,6 +244,7 @@ int RediSearch_Init(RedisModuleCtx *ctx, int mode) {
     return REDISMODULE_ERR;
   }
 
+  Initialize_KeyspaceNotifications(ctx);
   Initialize_CommandFilter(ctx);
   Initialize_RdbNotifications(ctx);
   Initialize_RoleChangeNotifications(ctx);

--- a/src/notifications.c
+++ b/src/notifications.c
@@ -268,6 +268,20 @@ void ShutdownEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subevent,
   RediSearch_CleanupModule();
 }
 
+void Initialize_KeyspaceNotifications(RedisModuleCtx *ctx) {
+  RedisModule_SubscribeToKeyspaceEvents(ctx,
+    REDISMODULE_NOTIFY_GENERIC | REDISMODULE_NOTIFY_HASH |
+    REDISMODULE_NOTIFY_STRING |
+    REDISMODULE_NOTIFY_EXPIRED | REDISMODULE_NOTIFY_EVICTED |
+    REDISMODULE_NOTIFY_LOADED | REDISMODULE_NOTIFY_MODULE,
+    HashNotificationCallback);
+
+  if (RedisModule_SubscribeToServerEvent && getenv("RS_GLOBAL_DTORS")) {
+    RedisModule_Log(ctx, "notice", "%s", "Subscribe to clear resources on shutdown");
+    RedisModule_SubscribeToServerEvent(ctx, RedisModuleEvent_Shutdown, ShutdownEvent);
+  }
+}
+
 void Initialize_CommandFilter(RedisModuleCtx *ctx) {
   if (RSGlobalConfig.filterCommands) {
     RedisModule_RegisterCommandFilter(ctx, CommandFilterCallback, 0);

--- a/src/notifications.h
+++ b/src/notifications.h
@@ -10,6 +10,7 @@
 
 int HashNotificationCallback(RedisModuleCtx *ctx, int type, const char *event,
                              RedisModuleString *key);
+void Initialize_KeyspaceNotifications(RedisModuleCtx *ctx);
 void Initialize_CommandFilter(RedisModuleCtx *ctx);
 void Initialize_RdbNotifications(RedisModuleCtx *ctx);
 void Initialize_RoleChangeNotifications(RedisModuleCtx *ctx);

--- a/src/query.c
+++ b/src/query.c
@@ -1173,13 +1173,9 @@ static IndexIterator *query_EvalSingleTagNode(QueryEvalCtx *q, TagIndex *idx, Qu
                                               const FieldSpec *fs) {
   IndexIterator *ret = NULL;
 
-  // graph uses Tag fields for Range matching
-  // in which case the strings are casesensitive, and shouldn't be altered
-  // this is why we're skipping tag_strtolower which performs both lower-casing
-  // and escaping
-  //if (n->tn.str) {
-  //  tag_strtolower(n->tn.str, &n->tn.len, fs->tagOpts.tagFlags & TagField_CaseSensitive);
-  //}
+  if (n->tn.str) {
+    tag_strtolower(n->tn.str, &n->tn.len, fs->tagOpts.tagFlags & TagField_CaseSensitive);
+  }
 
   switch (n->type) {
     case QN_TOKEN: {

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -946,7 +946,14 @@ typedef struct RedisModuleTypeMethods {
 #define REDISMODULE_GET_API(name) \
     RedisModule_GetApi("RedisModule_" #name, ((void **)&RedisModule_ ## name))
 
-/* Default API declaration prefix (not 'extern' for backwards compatibility) */
+/* Default API declaration prefix: extern by default to avoid ASAN ODR
+ * violations when included in multiple translation units.
+ * Define REDISMODULE_MAIN in exactly one translation unit to provide
+ * the actual storage for these function pointers. */
+#ifndef REDISMODULE_MAIN
+#define REDISMODULE_API extern
+#endif
+
 #ifndef REDISMODULE_API
 #define REDISMODULE_API
 #endif

--- a/src/spec.c
+++ b/src/spec.c
@@ -2074,7 +2074,7 @@ void IndexSpec_AddToInfo(RedisModuleInfoCtx *ctx, IndexSpec *sp) {
   RedisModule_InfoAddFieldDouble(ctx, "key_table_size", TrieMap_MemUsage(sp->docs.dim.tm) / (float)0x100000);
   RedisModule_InfoAddFieldDouble("tag_overhead_size_mb", IndexSpec_collect_tags_overhead(sp) / (float)0x100000);
   RedisModule_InfoAddFieldDouble("text_overhead_size_mb", IndexSpec_collect_text_overhead(sp) / (float)0x100000);
-  RedisModule_InfoAddFieldDouble("total_index_memory_sz_mb", IndexSpec_TotalMemUsage(sp) / (float)0x100000);
+  RedisModule_InfoAddFieldDouble("total_index_memory_sz_mb", IndexSpec_TotalMemUsage(sp, 0, 0, 0) / (float)0x100000);
   RedisModule_InfoEndDictField(ctx);
 
   RedisModule_InfoAddFieldULongLong(ctx, "total_inverted_index_blocks", TotalIIBlocks);

--- a/tests/cpptests/redismock/internal.h
+++ b/tests/cpptests/redismock/internal.h
@@ -254,6 +254,8 @@ struct KVDB {
   static std::vector<KVDB *> dbs;
 };
 
+typedef int (*RedisModule_GetApiFunctionType)(const char *name, void *pp);
+
 struct RedisModuleCtx {
   RedisModule_GetApiFunctionType getApi = NULL;
   bool automemory = false;

--- a/tests/cpptests/test_cpp_forkgc.cpp
+++ b/tests/cpptests/test_cpp_forkgc.cpp
@@ -86,10 +86,10 @@ class FGCTest : public ::testing::Test {
     pthread_create(&thread, NULL, cbWrapper, args);
   }
   void TearDown() override {
+    // Wait for the gc thread to finish before dropping the index
+    // to avoid use-after-free.
+    pthread_join(thread, NULL);
     RediSearch_DropIndex(sp);
-    // Detach from the gc to make sure we are not stuck on waiting
-    // for the pauseState to be changed.
-    pthread_detach(thread);
   }
 
   IndexSpec *createIndex(RedisModuleCtx *ctx) {

--- a/tests/pytests/test_spell_check.py
+++ b/tests/pytests/test_spell_check.py
@@ -55,9 +55,9 @@ def testBasicSpellCheck(env):
 def testBasicSpellCheckWithNoResult(env):
     env.cmd('ft.create', 'idx', 'ON', 'HASH', 'SCHEMA', 'name', 'TEXT', 'body', 'TEXT')
     with env.getClusterConnectionIfNeeded() as r:
-        r.execute_command('ft.add', 'idx', 'doc1', 1.0, 'FIELDS', 'name', 'name1', 'body', 'body1')
-        r.execute_command('ft.add', 'idx', 'doc2', 1.0, 'FIELDS', 'name', 'name2', 'body', 'body2')
-        r.execute_command('ft.add', 'idx', 'doc3', 1.0, 'FIELDS', 'name', 'name2', 'body', 'name2')
+        r.execute_command('hset', 'doc1', 'name', 'name1', 'body', 'body1')
+        r.execute_command('hset', 'doc2', 'name', 'name2', 'body', 'body2')
+        r.execute_command('hset', 'doc3', 'name', 'name2', 'body', 'name2')
     waitForIndex(env, 'idx')
     env.expect('ft.spellcheck', 'idx', 'somenotexiststext').equal([['TERM', 'somenotexiststext', []]])
 
@@ -74,9 +74,9 @@ def testSpellCheckWithIncludeDict(env):
     env.cmd('ft.dictadd', 'dict', 'name3', 'name4', 'name5')
     env.cmd('ft.create', 'idx', 'ON', 'HASH', 'SCHEMA', 'name', 'TEXT', 'body', 'TEXT')
     with env.getClusterConnectionIfNeeded() as r:
-        r.execute_command('ft.add', 'idx', 'doc1', 1.0, 'FIELDS', 'name', 'name1', 'body', 'body1')
-        r.execute_command('ft.add', 'idx', 'doc2', 1.0, 'FIELDS', 'name', 'name2', 'body', 'body2')
-        r.execute_command('ft.add', 'idx', 'doc3', 1.0, 'FIELDS', 'name', 'name2', 'body', 'name2')
+        r.execute_command('hset', 'doc1', 'name', 'name1', 'body', 'body1')
+        r.execute_command('hset', 'doc2', 'name', 'name2', 'body', 'body2')
+        r.execute_command('hset', 'doc3', 'name', 'name2', 'body', 'name2')
     waitForIndex(env, 'idx')
 
     res = env.cmd('ft.spellcheck', 'idx', 'name', 'TERMS', 'INCLUDE', 'dict')
@@ -91,9 +91,9 @@ def testSpellCheckWithDuplications(env):
     env.cmd('ft.dictadd', 'dict', 'name1', 'name4', 'name5')
     env.cmd('ft.create', 'idx', 'ON', 'HASH', 'SCHEMA', 'name', 'TEXT', 'body', 'TEXT')
     with env.getClusterConnectionIfNeeded() as r:
-        r.execute_command('ft.add', 'idx', 'doc1', 1.0, 'FIELDS', 'name', 'name1', 'body', 'body1')
-        r.execute_command('ft.add', 'idx', 'doc2', 1.0, 'FIELDS', 'name', 'name2', 'body', 'body2')
-        r.execute_command('ft.add', 'idx', 'doc3', 1.0, 'FIELDS', 'name', 'name2', 'body', 'name2')
+        r.execute_command('hset', 'doc1', 'name', 'name1', 'body', 'body1')
+        r.execute_command('hset', 'doc2', 'name', 'name2', 'body', 'body2')
+        r.execute_command('hset', 'doc3', 'name', 'name2', 'body', 'name2')
     waitForIndex(env, 'idx')
 
     res = env.cmd('ft.spellcheck', 'idx', 'name', 'TERMS', 'INCLUDE', 'dict')
@@ -105,9 +105,9 @@ def testSpellCheckExcludeDict(env):
     env.cmd('ft.dictadd', 'dict', 'name')
     env.cmd('ft.create', 'idx', 'ON', 'HASH', 'SCHEMA', 'name', 'TEXT', 'body', 'TEXT')
     with env.getClusterConnectionIfNeeded() as r:
-        r.execute_command('ft.add', 'idx', 'doc1', 1.0, 'FIELDS', 'name', 'name1', 'body', 'body1')
-        r.execute_command('ft.add', 'idx', 'doc2', 1.0, 'FIELDS', 'name', 'name2', 'body', 'body2')
-        r.execute_command('ft.add', 'idx', 'doc3', 1.0, 'FIELDS', 'name', 'name2', 'body', 'name2')
+        r.execute_command('hset', 'doc1', 'name', 'name1', 'body', 'body1')
+        r.execute_command('hset', 'doc2', 'name', 'name2', 'body', 'body2')
+        r.execute_command('hset', 'doc3', 'name', 'name2', 'body', 'name2')
     waitForIndex(env, 'idx')
     env.expect('ft.spellcheck', 'idx', 'name', 'TERMS', 'EXCLUDE', 'dict').equal([])
     env.expect('ft.spellcheck', 'idx', 'name', 'TERMS', 'exclude', 'dict').equal([])
@@ -119,9 +119,9 @@ def testSpellCheckWrongArity(env):
     env.cmd('ft.dictadd', 'dict', 'name')
     env.cmd('ft.create', 'idx', 'ON', 'HASH', 'SCHEMA', 'name', 'TEXT', 'body', 'TEXT')
     with env.getClusterConnectionIfNeeded() as r:
-        r.execute_command('ft.add', 'idx', 'doc1', 1.0, 'FIELDS', 'name', 'name1', 'body', 'body1')
-        r.execute_command('ft.add', 'idx', 'doc2', 1.0, 'FIELDS', 'name', 'name2', 'body', 'body2')
-        r.execute_command('ft.add', 'idx', 'doc3', 1.0, 'FIELDS', 'name', 'name2', 'body', 'name2')
+        r.execute_command('hset', 'doc1', 'name', 'name1', 'body', 'body1')
+        r.execute_command('hset', 'doc2', 'name', 'name2', 'body', 'body2')
+        r.execute_command('hset', 'doc3', 'name', 'name2', 'body', 'name2')
     waitForIndex(env, 'idx')
     env.expect('ft.spellcheck', 'idx').raiseError()
     env.expect('ft.spellcheck', 'idx').raiseError()
@@ -130,9 +130,9 @@ def testSpellCheckBadFormat(env):
     env.cmd('ft.dictadd', 'dict', 'name')
     env.cmd('ft.create', 'idx', 'ON', 'HASH', 'SCHEMA', 'name', 'TEXT', 'body', 'TEXT')
     with env.getClusterConnectionIfNeeded() as r:
-        r.execute_command('ft.add', 'idx', 'doc1', 1.0, 'FIELDS', 'name', 'name1', 'body', 'body1')
-        r.execute_command('ft.add', 'idx', 'doc2', 1.0, 'FIELDS', 'name', 'name2', 'body', 'body2')
-        r.execute_command('ft.add', 'idx', 'doc3', 1.0, 'FIELDS', 'name', 'name2', 'body', 'name2')
+        r.execute_command('hset', 'doc1', 'name', 'name1', 'body', 'body1')
+        r.execute_command('hset', 'doc2', 'name', 'name2', 'body', 'body2')
+        r.execute_command('hset', 'doc3', 'name', 'name2', 'body', 'name2')
     waitForIndex(env, 'idx')
     env.expect('ft.spellcheck', 'idx', 'name', 'TERMS').raiseError()
     env.expect('ft.spellcheck', 'idx', 'name', 'TERMS', 'INCLUDE').raiseError()
@@ -146,9 +146,9 @@ def testSpellCheckNoneExistingDicts(env):
     env.cmd('ft.create', 'idx', 'ON', 'HASH',
             'SCHEMA', 'name', 'TEXT', 'body', 'TEXT')
     with env.getClusterConnectionIfNeeded() as r:
-        r.execute_command('ft.add', 'idx', 'doc1', 1.0, 'FIELDS', 'name', 'name1', 'body', 'body1')
-        r.execute_command('ft.add', 'idx', 'doc2', 1.0, 'FIELDS', 'name', 'name2', 'body', 'body2')
-        r.execute_command('ft.add', 'idx', 'doc3', 1.0, 'FIELDS', 'name', 'name2', 'body', 'name2')
+        r.execute_command('hset', 'doc1', 'name', 'name1', 'body', 'body1')
+        r.execute_command('hset', 'doc2', 'name', 'name2', 'body', 'body2')
+        r.execute_command('hset', 'doc3', 'name', 'name2', 'body', 'name2')
     waitForIndex(env, 'idx')
     env.expect('ft.spellcheck', 'idx', 'name', 'TERMS', 'INCLUDE', 'dict').raiseError()
     env.expect('ft.spellcheck', 'idx', 'name', 'TERMS', 'EXCLUDE', 'dict').raiseError()
@@ -157,8 +157,8 @@ def testSpellCheckResultsOrder(env):
     env.cmd('ft.dictadd', 'dict', 'name')
     env.cmd('ft.create', 'idx', 'ON', 'HASH', 'SCHEMA', 'name', 'TEXT', 'body', 'TEXT')
     with env.getClusterConnectionIfNeeded() as r:
-        r.execute_command('ft.add', 'idx', 'doc1', 1.0, 'FIELDS', 'name', 'Elior', 'body', 'body1')
-        r.execute_command('ft.add', 'idx', 'doc2', 1.0, 'FIELDS', 'name', 'Hila', 'body', 'body2')
+        r.execute_command('hset', 'doc1', 'name', 'Elior', 'body', 'body1')
+        r.execute_command('hset', 'doc2', 'name', 'Hila', 'body', 'body2')
     waitForIndex(env, 'idx')
     exp = [
         ['TERM', 'elioh', [['0.5', 'elior']]],


### PR DESCRIPTION
## Fixes CI failures on vector-low-level-api branch

### Summary of all fixes (7 commits)

**Commit 1: Deprecated GitHub Actions and build fixes**
- Upgraded `actions/upload-artifact@v3` → `v4` and `actions/checkout@v3` → `v4`
- Added missing `RedisModule_GetApiFunctionType` typedef in redismock `internal.h`
- Restored `REDISMODULE_MAIN` guard in `redismodule.h` to prevent ASAN ODR violations

**Commit 2: Restore keyspace notifications and fix FGCTest**
- Restored `Initialize_KeyspaceNotifications()` which was removed from the branch — this is the PRIMARY indexing trigger for HSET events
- Fixed FGCTest: `pthread_join` before `RediSearch_DropIndex` (was `pthread_detach`)
- Added lcov install step in coverage workflow, upgraded codecov v3→v4
- Updated Rust nightly from 2024-05-16 to 2024-09-15 for RedisJSON build

**Commit 3: Fix TAG query evaluation and IndexSpec_TotalMemUsage**
- Uncommented `tag_strtolower` call in `query.c` — without it, TAG queries like `@t:{FOO}` fail since the index stores lowercase
- Fixed `IndexSpec_TotalMemUsage(sp)` → `IndexSpec_TotalMemUsage(sp, 0, 0, 0)` (wrong arg count = undefined behavior)

**Commit 4: Fix coverage RedisJSON version**
- Coverage target called `get-redisjson` without `BRANCH`, defaulting to `master` which crashes. Added `BRANCH=$(REJSON_BRANCH)` to use 2.4

**Commit 5: Fix Document_Clear memory leaks**
- Uncommented `rm_free(field->name)` — was leaking ALL field names
- Fixed `multiVal` cleanup: was using `array_free()` on `rm_calloc`-allocated memory (wrong allocator)

**Commit 6: Fix LLAPI unit test crash (SIGSEGV)**
- Restored `DOCUMENT_F_OWNSTRINGS` strdup check in `addFieldCommon` — fields added after `Document_MakeStringsOwner` must have their names strdup'd, otherwise `Document_Clear` frees string literals

**Commit 7: Fix lcov 2.0 compatibility for coverage**
- Override readies `COVERAGE_COLLECT/RESET/REPORT` macros with `--ignore-errors` for lcov 2.0 (Ubuntu 24.04 ships 2.0 which is stricter than 1.x)

### CI Results
- **Sanitizer**: ✅ PASSED (all unit tests + flow tests + memcheck)
- **Basic-test**: 701/711 tests pass — 10 remaining failures are pre-existing coordinator-mode issues (spell_check tests use deprecated `FT.ADD`, aggregate error message format, vecsim `FT.CONFIG SET` unsupported in coordinator)
- **Coverage**: Fix for lcov 2.0 in latest commit

### CI Run References
- Original failed run: https://github.com/FalkorDB/RediSearch/actions/runs/22576418837
- Latest CI run: https://github.com/FalkorDB/RediSearch/actions/runs/22821742254